### PR TITLE
dhcpcd 9.4.x compatibility

### DIFF
--- a/att-ipv6/10-att-ipv6.sh
+++ b/att-ipv6/10-att-ipv6.sh
@@ -16,6 +16,8 @@ test -f "${confdir}/dhcpcd.conf" || {
   : > "${confdir}/dhcpcd.conf.tmp"
   cat >> "${confdir}/dhcpcd.conf.tmp" <<EOF
 allowinterfaces ${wan_iface}
+nodev
+noup
 ipv6only
 nooption domain_name_servers
 nooption domain_name


### PR DESCRIPTION
* `nodev`, otherwise dhcpcd finds no valid interfaces
* `noup`, prevents dhcpcd from bringing up interfaces in favor of UnifiOS